### PR TITLE
Support for LESS import options - [reference, inline, less, ...]

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var path = require('path');
 var namedRegexp = require('named-js-regexp');
 
 module.exports = function (css, resourcePath, aliases) {
-  var IMPORT_REGEX = namedRegexp(/^(:<import>@import\s+)(:<url_tag_open>url\()?\s*(:<quote_open>"|')(:<url>.+)\s*(:<quote_close>"|')(:<url_tag_close>\))?(:<context>.*);$/gm);
+  var IMPORT_REGEX = namedRegexp(/^(:<import>@import\s+)(:<less_import_options>\((reference|inline|less|css|once|multiple|optional)\)\s)?\s*(:<url_tag_open>url\()?\s*(:<quote_open>"|')(:<url>.+)\s*(:<quote_close>"|')(:<url_tag_close>\))?(:<context>.*);$/gm);
   var URL_REGEX = namedRegexp(/(:<url_tag_open>url\()\s*(:<quote_open>"|')?(:<url>.+?)\s*(:<quote_close>"|')?(:<url_tag_close>\))/gm);
   css = parse(css, IMPORT_REGEX);
   css = parse(css, URL_REGEX);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "css-aliases",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "description": "Lets you create custom aliases for CSS, less, SASS and etc. properties with an @alias rule",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For LESS style files, there was missing support for import options. Eg:

`@import (reference) "@alias/style.less"`

or

`@import (optional) "@alias/style.less"`

http://lesscss.org/features/#import-atrules-feature-import-options